### PR TITLE
feat(esign): Add addSignature method to sign and store to minio

### DIFF
--- a/src/internal/esigns/delivery/http/handler.ts
+++ b/src/internal/esigns/delivery/http/handler.ts
@@ -14,9 +14,8 @@ class Handler {
                 const body = await validateFormRequest(SignInput, req.body)
                 const signedFile = await this.usecase.Sign(body)
 
-                res.status(statusCode.OK).json(statusCode.OK)
+                res.status(statusCode.OK).json(signedFile)
             } catch (error) {
-                this.logger.error(error)
                 return next(error)
             }
         }

--- a/src/internal/esigns/entity/interface.ts
+++ b/src/internal/esigns/entity/interface.ts
@@ -5,4 +5,10 @@ export interface SignInput {
         category?: string
         code: string
     }
+    esigns: {
+        nik: string
+        passphrase: string
+        tampilan?: string
+        image?: boolean
+    }
 }

--- a/src/internal/esigns/entity/schema.ts
+++ b/src/internal/esigns/entity/schema.ts
@@ -7,4 +7,8 @@ export const SignInput = Joi.object({
         category: Joi.number().optional(),
         code: Joi.string().required(),
     }),
+    esigns: Joi.object({
+        nik: Joi.string().required(),
+        passphrase: Joi.string().required(),
+    }),
 })

--- a/src/pkg/lang/en.json
+++ b/src/pkg/lang/en.json
@@ -3,5 +3,7 @@
 
     "common.file.not.found": "File {{ attribute }} not found.",
 
-    "external.pdf.service.error": "Generate Footer PDF Service is down. Please try again in a few moments."
+    "external.pdf.service.error": "Generate Footer PDF Service is down. Please try again in a few moments.",
+
+    "external.esign.service.error": "Esign (BSrE) Service is down. Please try again in a few moments."
 }

--- a/src/pkg/lang/id.json
+++ b/src/pkg/lang/id.json
@@ -3,5 +3,7 @@
 
     "common.file.not.found": "File {{ attribute }} tidak ditemukan.",
 
-    "external.pdf.service.error": "Layanan Generate Footer PDF sedang down. Silakan coba lagi dalam beberapa saat."
+    "external.pdf.service.error": "Layanan Generate Footer PDF sedang down. Silakan coba lagi dalam beberapa saat.",
+
+    "external.esign.service.error": "Layanan Esign (BSrE) sedang down. Silakan coba lagi dalam beberapa saat."
 }


### PR DESCRIPTION
## Overview
- feat(esign): Add addSignature method to sign and store to minio
- Hit API eSign BSrE via gateway service

## Request
```
{
    "fileObjectKey": "TES-F4.pdf",
    "footers": {
        "qrcode": "https://sidebar.jabarprov.go.id/verification/document/tte/1234567890?source=qrcode",
        "code" : "A1B2C3D4E5",
        "category" : 1
    },
    "esigns": {
        "nik": "320xxxxxxxxxxxxxxxx",
        "passphrase": "my-passphrase"
    }
}
```

## Evidence:
project: SIDEBAR
title: feat(esign): Add addSignature method to sign and store to minio
participants: @fajarhikmal214 @samudra-ajri @indraprasetya154 @muhamadabduh 
screenshot: https://user-images.githubusercontent.com/79292118/221758866-8f4d7e72-8c61-4f49-9367-61fd738a0ad9.png