### PR TITLE
feat(esigns): Add subscribe and publish method for esign process and esign progress update

### DIFF
--- a/src/internal/esigns/entity/enums.ts
+++ b/src/internal/esigns/entity/enums.ts
@@ -1,0 +1,7 @@
+export enum EsignProgressUpdateStatus {
+    INITIATE = 'INITIATE',
+    GENERATE_PDF = 'GENERATE_PDF',
+    GENERATE_FOOTER = 'GENERATE_FOOTER',
+    ADD_SIGNATURE = 'ADD_SIGNATURE',
+    ERROR = 'ERROR',
+}

--- a/src/internal/esigns/entity/interface.ts
+++ b/src/internal/esigns/entity/interface.ts
@@ -1,4 +1,7 @@
+import { EsignProgressUpdateStatus } from './enums'
+
 export interface SignInput {
+    id: string
     generate: {
         url: string
     }
@@ -13,4 +16,14 @@ export interface SignInput {
         tampilan?: string
         image?: boolean
     }
+}
+
+export interface ProgressUpdatePayload {
+    id: string
+    status: EsignProgressUpdateStatus
+    fileInfo?: {
+        fileName?: string
+        fileUrl?: string
+    }
+    message?: string
 }

--- a/src/internal/esigns/usecase/usecase.ts
+++ b/src/internal/esigns/usecase/usecase.ts
@@ -1,16 +1,18 @@
 import { AxiosRequestConfig } from 'axios'
 import winston from 'winston'
 import FormData from 'form-data'
+import { NatsConnection, StringCodec, Subscription } from 'nats'
 import { randomUUID } from 'crypto'
 import MinioClient from '../../../external/storage/minio'
 import PdfGenerateUsecase from '../../pdf-generations/usecase/usecase'
-import { SignInput } from '../entity/interface'
+import { ProgressUpdatePayload, SignInput } from '../entity/interface'
 import HttpClient from '../../../helpers/http-client'
 import { Config } from '../../../config/config.interface'
 import error from '../../../pkg/error'
 import statusCode from '../../../pkg/statusCode'
 import lang from '../../../pkg/lang'
 import createFileObject from '../../../helpers/createFileObject'
+import { EsignProgressUpdateStatus } from '../entity/enums'
 
 class Usecase {
     private minioClient: MinioClient
@@ -20,7 +22,8 @@ class Usecase {
     constructor(
         private config: Config,
         private logger: winston.Logger,
-        private pdfGenerateUsecase: PdfGenerateUsecase
+        private pdfGenerateUsecase: PdfGenerateUsecase,
+        private nats: NatsConnection
     ) {
         this.minioClient = new MinioClient(config)
 
@@ -34,31 +37,104 @@ class Usecase {
         }
     }
 
-    public async Sign(body: SignInput) {
-        // Generate PDF
-        const generatedPdfFile = await this.pdfGenerateUsecase.GeneratePdf(
-            body.generate.url
-        )
+    public async subscribe() {
+        try {
+            const subject = this.config.nats.subject.esignProcess
+            const queue = this.config.nats.queueName
 
-        // Generate Footer
-        const generatedFooterFile = await this.addFooterPdf(
-            body.footers,
-            generatedPdfFile
-        )
+            const subscribe = this.nats.subscribe(subject, { queue })
+            this.logger.info(`listening for ${subject} requests...`)
 
-        // Sign PDF
-        const signedFile = await this.addSignature(
-            body.esigns,
-            generatedFooterFile
-        )
+            await this.handleRequest(queue, subscribe)
+        } catch (error: any) {
+            this.logger.error(error.message)
+        }
+    }
 
-        return signedFile
+    private async handleRequest(name: string, subscribe: Subscription) {
+        const sc = StringCodec()
+
+        const p = 12 - name.length
+        const pad = ''.padEnd(p)
+
+        for await (const message of subscribe) {
+            const { data } = JSON.parse(sc.decode(message.data))
+
+            if (data) {
+                this.logger.info(
+                    `[${name}]:${pad} #${subscribe.getProcessed()} handled`
+                )
+
+                await this.sign(data)
+            }
+        }
+    }
+
+    private async progressUpdate(data: ProgressUpdatePayload) {
+        this.nats.publish(
+            this.config.nats.subject.esignProgressUpdate,
+            StringCodec().encode(JSON.stringify(data))
+        )
+    }
+
+    private async sign(body: SignInput) {
+        await this.progressUpdate({
+            id: body.id,
+            status: EsignProgressUpdateStatus.INITIATE,
+        })
+
+        try {
+            // Generate PDF
+            const generatedPdfFile = await this.pdfGenerateUsecase.GeneratePdf(
+                body.generate.url
+            )
+
+            if (generatedPdfFile) {
+                await this.progressUpdate({
+                    id: body.id,
+                    status: EsignProgressUpdateStatus.GENERATE_PDF,
+                })
+            }
+
+            // Generate Footer
+            const generatedFooterFile = await this.addFooterPdf(
+                body.footers,
+                generatedPdfFile
+            )
+
+            if (generatedFooterFile) {
+                await this.progressUpdate({
+                    id: body.id,
+                    status: EsignProgressUpdateStatus.GENERATE_FOOTER,
+                })
+            }
+
+            // Sign PDF
+            const fileInfo = await this.addSignature(
+                body.esigns,
+                generatedFooterFile
+            )
+
+            if (fileInfo) {
+                await this.progressUpdate({
+                    id: body.id,
+                    status: EsignProgressUpdateStatus.ADD_SIGNATURE,
+                    fileInfo,
+                })
+            }
+        } catch (error: any) {
+            await this.progressUpdate({
+                id: body.id,
+                status: EsignProgressUpdateStatus.ERROR,
+                message: error.message,
+            })
+        }
     }
 
     private async addSignature(
         body: SignInput['esigns'],
         originalFile: Buffer
-    ) {
+    ): Promise<ProgressUpdatePayload['fileInfo']> {
         const formData = new FormData()
         const originalFileName = randomUUID() + '.pdf'
 
@@ -85,14 +161,9 @@ class Usecase {
                 metaData
             )
 
-            const file_url = `${this.config.core_api.url}/files/${fileName}`
+            const fileUrl = `${this.config.core_api.url}/files/${fileName}`
 
-            return {
-                data: {
-                    fileName,
-                    file_url,
-                },
-            }
+            return { fileName, fileUrl }
         } catch (err: any) {
             if (err.response) {
                 throw new error(

--- a/src/internal/esigns/usecase/usecase.ts
+++ b/src/internal/esigns/usecase/usecase.ts
@@ -54,15 +54,12 @@ class Usecase {
     private async handleRequest(name: string, subscribe: Subscription) {
         const sc = StringCodec()
 
-        const p = 12 - name.length
-        const pad = ''.padEnd(p)
-
         for await (const message of subscribe) {
             const { data } = JSON.parse(sc.decode(message.data))
 
             if (data) {
                 this.logger.info(
-                    `[${name}]:${pad} #${subscribe.getProcessed()} handled`
+                    `[${name}]: #${subscribe.getProcessed()} handled`
                 )
 
                 await this.sign(data)


### PR DESCRIPTION
## Overview
- feat(esigns): Add subscribe and publish method for esign process and esign progress update
- Subscribe subject `esignProcess` from `office-service-v2`
- Publish subject `esignProgressUpdate` after each completed e-sign sub-process

## Evidence:
project: SIDEBAR
title: feat(esigns): Add subscribe and publish method for esign process and esign progress update
participants: @fajarhikmal214 @samudra-ajri @muhamadabduh @azophy 
screenshot: https://user-images.githubusercontent.com/79292118/223044298-1e24b2e0-4758-4a2a-89dc-f3677e8ee694.png