### PR TITLE
feat(esign): Add storing data payload from publisher and store when ADD_SIGNATURE done

### DIFF
--- a/src/internal/esigns/entity/interface.ts
+++ b/src/internal/esigns/entity/interface.ts
@@ -2,6 +2,13 @@ import { EsignProgressUpdateStatus } from './enums'
 
 export interface SignInput {
     id: string
+    latestActivityId: string
+
+    updateDocumentActivityInput: object
+    updateDocumentInput: object
+    createDocumentRevisionInput: object
+    createDocumentActivityInput: object
+
     generate: {
         url: string
     }
@@ -23,6 +30,13 @@ export interface SignInput {
 
 export interface ProgressUpdatePayload {
     id: string
+    latestActivityId: string
+
+    updateDocumentActivityInput: object
+    updateDocumentInput: object
+    createDocumentRevisionInput: object
+    createDocumentActivityInput: object
+
     status: EsignProgressUpdateStatus
     fileInfo?: {
         fileName?: string

--- a/src/internal/esigns/usecase/usecase.ts
+++ b/src/internal/esigns/usecase/usecase.ts
@@ -67,7 +67,7 @@ class Usecase {
         }
     }
 
-    private async progressUpdate(data: ProgressUpdatePayload) {
+    private async progressUpdate(data: Partial<ProgressUpdatePayload>) {
         this.nats.publish(
             this.config.nats.subject.esignProgressUpdate,
             StringCodec().encode(JSON.stringify(data))
@@ -126,11 +126,14 @@ class Usecase {
             )
 
             if (fileInfo) {
-                await this.progressUpdate({
-                    id: body.id,
-                    status: EsignProgressUpdateStatus.ADD_SIGNATURE,
-                    fileInfo,
-                })
+                const progressUpdatePayload: Partial<ProgressUpdatePayload> =
+                    Object.assign({}, body)
+
+                progressUpdatePayload.status =
+                    EsignProgressUpdateStatus.ADD_SIGNATURE
+                progressUpdatePayload.fileInfo = fileInfo
+
+                await this.progressUpdate(progressUpdatePayload)
             }
         } catch (error: any) {
             await this.progressUpdate({


### PR DESCRIPTION
## Overview
- feat(esign): Add storing data payload from publisher and store when ADD_SIGNATURE done

## Evidence:
project: SIDEBAR
title: feat(esign): Add storing data payload from publisher and store when ADD_SIGNATURE done
participants: @fajarhikmal214 @muhamadabduh @azophy 
screenshot: https://user-images.githubusercontent.com/79292118/224588867-6ceea611-937f-489e-8122-afdca8225c42.png