### PR TITLE
feat(esign): Remove passphrase to avoid going into logging

### DIFF
--- a/src/internal/esigns/entity/interface.ts
+++ b/src/internal/esigns/entity/interface.ts
@@ -23,7 +23,7 @@ export interface SignInput {
     }
     esigns: {
         nik: string
-        passphrase: string
+        passphrase?: string
         tampilan?: string
         image?: boolean
     }

--- a/src/internal/esigns/usecase/usecase.ts
+++ b/src/internal/esigns/usecase/usecase.ts
@@ -131,6 +131,9 @@ class Usecase {
             )
 
             if (fileInfo) {
+                // To avoid passphrase going into logging
+                delete body.esigns.passphrase
+
                 const progressUpdatePayload: Partial<ProgressUpdatePayload> =
                     Object.assign({}, body)
 
@@ -158,7 +161,7 @@ class Usecase {
         const originalFileName = randomUUID() + '.pdf'
 
         const passphrase = passphraseDecryption(
-            body.passphrase,
+            body.passphrase!,
             this.config.esign.passphraseEncryptionSecretKey
         )
 


### PR DESCRIPTION
## Overview
- feat(esign): Remove passphrase to avoid going into logging

## Evidence:
project: SIDEBAR
title: feat(esign): Remove passphrase to avoid going into logging
participants: @fajarhikmal214 @samudra-ajri @muhamadabduh @azophy 
screenshot: https://user-images.githubusercontent.com/79292118/224908138-ae42213a-b98c-4344-9311-e849c9827d23.png